### PR TITLE
Allow using system packages or external install for gtest

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -52,7 +52,9 @@ jobs:
           # CONFIG_SITE.local for GitHub Actions CI
           CHECK_RELEASE=NO
           BUILD_IOCS=YES
-          BUILD_TESTS=YES
+
+          # Enable building of unit tests
+          BUILD_XSPD_TESTS=YES
 
           WITH_BOOST=NO
           WITH_PVA=YES
@@ -106,11 +108,9 @@ jobs:
           echo "RELEASE.local created:"
           cat configure/RELEASE.local
 
-      # TODO: Check why the non-devel deps are not being pulled in
-      # Epics bundle rpm should be converted to require devel versions of packages
       - name: Install required system packages
         run: |
-          dnf -y install curl-devel zeromq-devel zlib-devel blosc-devel hdf5-devel libtiff-devel libjpeg-devel libaec-devel libxml2-devel
+          dnf -y install curl-devel
 
       - name: Build ADXSPD driver and unit tests
         run: |
@@ -118,4 +118,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          ./bin/linux-x86_64/TestADXSPD
+          ./xspdApp/tests/O.linux-x86_64/TestADXSPD

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -34,15 +34,25 @@ CHECK_RELEASE = YES
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
-BUILD_TESTS=NO
+# By default, don't build unit tests.
+# If building tests, by default build gtest from source.
+BUILD_XSPD_TESTS=NO
 GTEST_EXTERNAL=NO
+#GTEST_LIB=
 
-# By defau
+# By default use system curl library.
 CURL_EXTERNAL=YES
 #CURL_LIB=
 
+# By default use system zmq library
 ZMQ_EXTERNAL=YES
 #ZMQ_LIB=
+
+# Specify whether or not to use system zlib library. Note this setting is also set in
+# the shared AREA_DETECTOR CONFIG_SITE files, but we list it here to make it clear
+# that the driver can override it if needed.
+#ZLIB_EXTERNAL=YES
+#ZLIB_LIB=
 
 # Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -35,8 +35,14 @@ CHECK_RELEASE = YES
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
 BUILD_TESTS=NO
+GTEST_EXTERNAL=NO
 
+# By defau
 CURL_EXTERNAL=YES
+#CURL_LIB=
+
+ZMQ_EXTERNAL=YES
+#ZMQ_LIB=
 
 # Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE

--- a/iocs/xspdIOC/xspdApp/src/Makefile
+++ b/iocs/xspdIOC/xspdApp/src/Makefile
@@ -14,14 +14,38 @@ $(PROD_NAME)_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Mai
 # Add any libraries built by the EPICS build system here
 $(PROD_NAME)_LIBS += ADXSPD cpr
 
-ifdef ZMQ_LIB
-  zmq_DIR        += $(ZMQ_LIB)
-  PROD_LIBS      += zmq
+ifeq ($(GTEST_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += gtest gmock
 else
-  PROD_SYS_LIBS  += zmq
+  ifdef GTEST_LIB
+    gtest_DIR        += $(GTEST_LIB)
+    $(PROD_NAME)_LIBS      += gtest gmock
+  else
+    $(PROD_NAME)_SYS_LIBS += gtest gmock
+  endif
 endif
 
-PROD_SYS_LIBS += curl
+ifeq ($(ZMQ_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += zmq
+else
+  ifdef ZMQ_LIB
+    zmq_DIR        += $(ZMQ_LIB)
+    $(PROD_NAME)_LIBS      += zmq
+  else
+    $(PROD_NAME)_SYS_LIBS  += zmq
+  endif
+endif
+
+ifeq ($(CURL_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += curl
+else
+  ifdef CURL_LIB
+    curl_DIR        += $(CURL_LIB)
+    $(PROD_NAME)_LIBS      += curl
+  else
+    $(PROD_NAME)_SYS_LIBS += curl
+  endif
+endif
 
 include $(ADCORE)/ADApp/commonDriverMakefile
 

--- a/xspdApp/Makefile
+++ b/xspdApp/Makefile
@@ -3,7 +3,7 @@ include $(TOP)/configure/CONFIG
 #----------------------------------------
 
 DIRS := $(DIRS) src
-ifeq ($(BUILD_TESTS), YES)
+ifeq ($(BUILD_XSPD_TESTS), YES)
 DIRS := $(DIRS) tests
 tests_DEPEND_DIRS += src
 endif

--- a/xspdApp/tests/Makefile
+++ b/xspdApp/tests/Makefile
@@ -6,7 +6,7 @@ include $(TOP)/configure/CONFIG
 USR_CPPFLAGS += -std=c++17
 
 PROD_NAME = TestADXSPD
-PROD_IOC = $(PROD_NAME)
+TESTPROD_IOC = $(PROD_NAME)
 
 $(PROD_NAME)_SRCS += TestADXSPDMain.cpp
 $(PROD_NAME)_SRCS += TestXSPDAPI.cpp

--- a/xspdApp/tests/Makefile
+++ b/xspdApp/tests/Makefile
@@ -5,26 +5,61 @@ include $(TOP)/configure/CONFIG
 
 USR_CPPFLAGS += -std=c++17
 
-PROD_IOC = TestADXSPD
+PROD_NAME = TestADXSPD
+PROD_IOC = $(PROD_NAME)
 
-TestADXSPD_SRCS += TestADXSPDMain.cpp
-# TestADXSPD_SRCS += ADXSPDTestUtils.cpp
-TestADXSPD_SRCS += TestXSPDAPI.cpp
-TestADXSPD_SRCS += MockXSPDAPI.cpp
+$(PROD_NAME)_SRCS += TestADXSPDMain.cpp
+$(PROD_NAME)_SRCS += TestXSPDAPI.cpp
+$(PROD_NAME)_SRCS += MockXSPDAPI.cpp
 
-# Add additional test source files here
-# TestADXSPD_SRCS +=
+$(PROD_NAME)_LIBS += ADXSPD ADBase asyn cpr
 
-TestADXSPD_LIBS += ADXSPD ADBase asyn cpr gtest gmock $(EPICS_BASE_IOC_LIBS)
-
-ifdef ZMQ_LIB
-  zmq_DIR        += $(ZMQ_LIB)
-  TestADXSPD_LIBS      += zmq
+ifeq ($(GTEST_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += gmock gtest
 else
-  TestADXSPD_SYS_LIBS  += zmq
+  ifdef GTEST_LIB
+    gtest_DIR        += $(GTEST_LIB)
+    $(PROD_NAME)_LIBS      += gmock gtest
+  else
+    $(PROD_NAME)_SYS_LIBS += gmock gtest
+  endif
 endif
 
-TestADXSPD_SYS_LIBS += curl z
+ifeq ($(ZMQ_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += zmq
+else
+  ifdef ZMQ_LIB
+    zmq_DIR        += $(ZMQ_LIB)
+    $(PROD_NAME)_LIBS      += zmq
+  else
+    $(PROD_NAME)_SYS_LIBS  += zmq
+  endif
+endif
+
+ifeq ($(CURL_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += curl
+else
+  ifdef CURL_LIB
+    curl_DIR        += $(CURL_LIB)
+    $(PROD_NAME)_LIBS      += curl
+  else
+    $(PROD_NAME)_SYS_LIBS += curl
+  endif
+endif
+
+ifeq ($(ZLIB_EXTERNAL), NO)
+  $(PROD_NAME)_LIBS += zlib
+else
+  ifdef ZLIB_LIB
+    zlib_DIR        += $(ZLIB_LIB)
+    $(PROD_NAME)_LIBS      += z
+  else
+    $(PROD_NAME)_SYS_LIBS += z
+  endif
+endif
+
+$(PROD_NAME)_LIBS += $(EPICS_BASE_IOC_LIBS)
+
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/xspdSupport/Makefile
+++ b/xspdSupport/Makefile
@@ -9,7 +9,7 @@ DIRS := $(DIRS) json
 DIRS := $(DIRS) magic_enum
 DIRS := $(DIRS) cpr
 
-ifeq ($(BUILD_TESTS), YES)
+ifeq ($(BUILD_XSPD_TESTS), YES)
 ifeq ($(GTEST_EXTERNAL), NO)
 DIRS := $(DIRS) gtest
 endif

--- a/xspdSupport/Makefile
+++ b/xspdSupport/Makefile
@@ -10,7 +10,9 @@ DIRS := $(DIRS) magic_enum
 DIRS := $(DIRS) cpr
 
 ifeq ($(BUILD_TESTS), YES)
+ifeq ($(GTEST_EXTERNAL), NO)
 DIRS := $(DIRS) gtest
+endif
 endif
 
 #=============================


### PR DESCRIPTION
- **Add check to API to make sure variable path in response matches request**
- **Apply linter**
- **Working to allow using system gtest/gmock instead of building from source**
